### PR TITLE
Fix HTML syntax error and remove duplicate PhotoSwipe initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
         </div>
       </div>
       <div class="inner">
-        <div class="copyright">Copyright&copy;shadowkrr. All Rights Reserved.</>
+        <div class="copyright">Copyright&copy;shadowkrr. All Rights Reserved.</div>
         </div>
     </footer>
   </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,3 @@
-// PhotoSwipe
-initPhotoSwipeFromDOM('.my-gallery');
 
 $(function () {
 


### PR DESCRIPTION
- Fix unclosed div tag in footer copyright section (index.html:368)
- Remove duplicate PhotoSwipe initialization from script.js to prevent conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)